### PR TITLE
Solved error error TS6046

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,10 +1,9 @@
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
-/* This code solves these problems:
-
+/* 
+This code solves these problems:
 tsconfig.base.json(14,15): error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.
 Error: tsconfig.base.json(14,15): error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.
-
- */
+*/
 {
   "compileOnSave": false,
   "compilerOptions": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,26 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+/* This code solves these problems:
+
+tsconfig.base.json(14,15): error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.
+Error: tsconfig.base.json(14,15): error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.
+
+ */
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "es2015",
+    "module": "amd",
+    "lib": [
+      "es2018",
+      "dom"
+    ]
+  }
+}


### PR DESCRIPTION
This file tsconfig.base.json solves the following problem:

tsconfig.base.json(14,15): error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.
Error: tsconfig.base.json(14,15): error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'esnext'.

Change the module value=> "module": "amd",